### PR TITLE
Sync with system color scheme instead of ModeSwitch

### DIFF
--- a/schemas/com.github.alecaddd.sequeler.gschema.xml.in
+++ b/schemas/com.github.alecaddd.sequeler.gschema.xml.in
@@ -54,12 +54,6 @@
 			<description>Automatically Save a Quick Connections into the Database Library.</description>
 		</key>
 
-		<key name="dark-theme" type="b">
-			<default>false</default>
-			<summary>Use dark theme</summary>
-			<description>Switch between Light and Dark theme.</description>
-		</key>
-
 		<key name="version" type="s">
 			<default>""</default>
 			<summary>Current Version</summary>

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -99,6 +99,26 @@ public class Sequeler.Application : Gtk.Application {
         return window;
     }
 
+    private static bool granite_color_scheme_to_gtk_dark_theme (Binding binding, Value granite_prop, ref Value gtk_prop) {
+        gtk_prop.set_boolean ((Granite.Settings.ColorScheme) granite_prop == Granite.Settings.ColorScheme.DARK);
+        return true;
+    }
+
+    protected override void startup () {
+        base.startup ();
+
+        // Follow OS-wide dark preference
+        unowned var granite_settings = Granite.Settings.get_default ();
+        unowned var gtk_settings = Gtk.Settings.get_default ();
+
+        granite_settings.bind_property ("prefers-color-scheme", gtk_settings, "gtk-application-prefer-dark-theme",
+            BindingFlags.DEFAULT | BindingFlags.SYNC_CREATE,
+            // FIXME: Using the lambda expression here causes Window not being freed when it's destroyed.
+            // Maybe due to this issue in vala: https://gitlab.gnome.org/GNOME/vala/-/issues/957
+            (BindingTransformFunc) granite_color_scheme_to_gtk_dark_theme
+        );
+    }
+
     protected override void activate () {
         this.add_new_window ();
     }

--- a/src/Layouts/HeaderBar.vala
+++ b/src/Layouts/HeaderBar.vala
@@ -26,7 +26,6 @@ public class Sequeler.Layouts.HeaderBar : Gtk.HeaderBar {
     private Gtk.Button new_db_button;
     private Gtk.Button delete_db_button;
     private Gtk.Button edit_db_button;
-    private Granite.ModeSwitch mode_switch;
     private Gtk.Popover menu_popover;
 
     public bool logged_out { get; set; }
@@ -85,19 +84,6 @@ public class Sequeler.Layouts.HeaderBar : Gtk.HeaderBar {
         delete_db_button.visible = false;
         delete_db_button.no_show_all = true;
 
-        mode_switch = new Granite.ModeSwitch.from_icon_name ("display-brightness-symbolic", "weather-clear-night-symbolic");
-        mode_switch.primary_icon_tooltip_text = _("Light background");
-        mode_switch.secondary_icon_tooltip_text = _("Dark background");
-        mode_switch.valign = Gtk.Align.CENTER;
-        mode_switch.bind_property ("active", settings, "dark-theme");
-        mode_switch.notify.connect (() => {
-            Gtk.Settings.get_default ().gtk_application_prefer_dark_theme = settings.dark_theme;
-        });
-
-        if (settings.dark_theme) {
-            mode_switch.active = true;
-        }
-
         var new_window_item = new_menuitem (_("New Window"), "<Control>n");
         new_window_item.action_name = Sequeler.Services.ActionManager.ACTION_PREFIX + Sequeler.Services.ActionManager.ACTION_NEW_WINDOW;
 
@@ -140,8 +126,6 @@ public class Sequeler.Layouts.HeaderBar : Gtk.HeaderBar {
         pack_start (delete_db_button);
 
         pack_end (open_menu);
-        pack_end (headerbar_separator ());
-        pack_end (mode_switch);
     }
 
     private Gtk.ModelButton new_menuitem (string label, string accels) {

--- a/src/Services/Settings.vala
+++ b/src/Services/Settings.vala
@@ -52,10 +52,6 @@ public class Sequeler.Services.Settings : GLib.Settings {
         get { return get_int ("limit-results"); }
         set { set_int ("limit-results", value); }
     }
-    public bool dark_theme {
-        get { return get_boolean ("dark-theme"); }
-        set { set_boolean ("dark-theme", value); }
-    }
     public bool save_quick {
         get { return get_boolean ("save-quick"); }
         set { set_boolean ("save-quick", value); }

--- a/src/Window.vala
+++ b/src/Window.vala
@@ -60,8 +60,6 @@ public class Sequeler.Window : Gtk.ApplicationWindow {
     }
 
     private void build_ui () {
-        Gtk.Settings.get_default ().gtk_application_prefer_dark_theme = settings.dark_theme;
-
         var css_provider = new Gtk.CssProvider ();
         css_provider.load_from_resource ("/com/github/alecaddd/sequeler/stylesheet.css");
 


### PR DESCRIPTION
I don't see other modern apps use a ModeSwitch to manually toggle color scheme instead of syncing with the color scheme of the system.
